### PR TITLE
Repo: update readme narrative information and other details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,104 @@
 
 ![Build master](https://img.shields.io/travis/OpenST/organization-contracts/master.svg?label=build%20master&style=flat)
 ![Build develop](https://img.shields.io/travis/OpenST/organization-contracts/develop.svg?label=build%20develop&style=flat)
-![npm version](https://img.shields.io/npm/v/@openstfoundation/organization-contracts.svg?style=flat)
 [![Discuss on Discourse](https://img.shields.io/discourse/https/discuss.openst.org/topics.svg?style=flat)][discourse]
-[![Chat on Gitter](https://img.shields.io/gitter/room/OpenSTFoundation/SimpleToken.svg?style=flat)][gitter]
+[![Chat on Gitter](https://img.shields.io/gitter/room/ostdotcom/OST-Platform.svg?style=flat)][gitter]
 
-Organization contracts manage application permissions.
+An organization administers other contracts. For an individual contract or a system of contracts, an organization enables limiting execution of certain functions to the organization or other accounts it authorizes (e.g., "workers").
 
-## Instructions
+## Getting Started
 
-### Installation
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
-> Please add
+### Prerequisites
 
-### Usage
+Project requires [node] and [npm] to be installed.
 
-> Please add
-
-## Related Work
-
-[mosaic-contracts] and [openst-contracts] use this package to manage access control.
-
-## Contributing
-
-### Set-up
+### Cloning
 
 ```bash
 git clone git@github.com:OpenST/organization-contracts.git
+```
+
+### Installing
+
+Install npm packages:
+
+```bash
 cd organization-contracts
 npm install
+```
+## Usage
+
+The contracts and interfaces in this repository are primarily intended for use in other OpenST projects. Please see [Related Work].
+
+### Compiling the contracts
+
+The following npm script compiles updated contracts from the last call using [truffle]:
+
+```bash
+npm run compile
+```
+
+To compile all contracts:
+
+```bash
 npm run compile-all
-npm run ganache
+```
+
+### Testing the contracts
+
+We use the [ganache] blockchain for development. Before running the tests, start `ganache`:
+
+```bash
+npm run ganache-cli
+```
+
+Test the contracts using [truffle]:
+
+```bash
 npm run test
 ```
 
-### Guidelines
+### Linting
+
+[ESLint] is used to lint js files.
+
+To lint all js files within the `./test` and `./tool` directories, run:
+
+```bash
+npm run lint
+```
+
+## Related Work
+
+OpenST uses organization contracts and interfaces in [mosaic-contracts], [brandedtoken-contracts], and [openst-contracts] to scale, create, and define blockchain token economies.
+
+## Contributing
 
 There are multiple ways to contribute to this project. However, before contributing, please first review the [Code of Conduct].
 
 We track our [issues] on GitHub.
 
-To contribute code, please ensure that your read the [developer guidelines] first.
+To contribute code, please review our [Developer Guidelines] and ensure that your submissions adhere to the [Style Guide]; please also be aware, this project is under active development and we have not yet established firm contribution guidelines or acceptance criteria.
 
 ### Community
 
 * [Forum][discourse]
-* [Gitter]
+* [Gitter][gitter]
 
-[code of conduct]: https://github.com/OpenST/developer-guidelines/blob/develop/CODE_OF_CONDUCT.md
+[brandedtoken-contracts]: https://github.com/OpenSTFoundation/brandedtoken-contracts
+[code of conduct]: https://github.com/OpenST/developer-guidelines/blob/master/CODE_OF_CONDUCT.md
 [developer guidelines]: https://github.com/OpenST/developer-guidelines
 [discourse]: https://discuss.openst.org/
-[gitter]: https://gitter.im/OpenSTFoundation/SimpleToken
-[mosaic-contracts]: https://github.com/OpenSTFoundation/mosaic-contracts
-[openst-contracts]: https://github.com/OpenSTFoundation/openst-contracts
+[eslint]: https://eslint.org
+[ganache]: https://github.com/trufflesuite/ganache
+[gitter]: https://gitter.im/ostdotcom/OST-Platform
 [issues]: https://github.com/OpenST/organization-contracts/issues
+[mosaic-contracts]: https://github.com/OpenSTFoundation/mosaic-contracts
+[node]: https://nodejs.org/en/
+[npm]: https://www.npmjs.com/get-npm
+[openst-contracts]: https://github.com/OpenSTFoundation/openst-contracts
+[related work]: #related-work
+[style guide]: https://github.com/OpenST/developer-guidelines/blob/master/SOLIDITY_STYLE_GUIDE.md
+[truffle]: https://github.com/trufflesuite/truffle

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ The contracts and interfaces in this repository are primarily intended for use i
 
 ### Compiling the contracts
 
-The following npm script compiles updated contracts from the last call using [truffle]:
+The following npm script compiles updated contracts since the last compile using [truffle]:
 
 ```bash
 npm run compile
 ```
 
-To compile all contracts:
+To compile all contracts, including the ones that haven't changed:
 
 ```bash
 npm run compile-all
@@ -58,7 +58,7 @@ npm run ganache-cli
 Test the contracts using [truffle]:
 
 ```bash
-npm run test
+npm test
 ```
 
 ### Linting
@@ -86,7 +86,7 @@ To contribute code, please review our [Developer Guidelines] and ensure that you
 ### Community
 
 * [Forum][discourse]
-* [Gitter][gitter]
+* [Gitter]
 
 [brandedtoken-contracts]: https://github.com/OpenSTFoundation/brandedtoken-contracts
 [code of conduct]: https://github.com/OpenST/developer-guidelines/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
This PR updates the readme's narrative information and installation and usage details.

It largely tracks the [OpenST readme](https://github.com/OpenST/openst-contracts), but there are some notable exceptions:
- the OpenST readme says it uses Ethlint a/k/a solium. This repo has solium config files, but has neither ethlint nor solium in its `package.json`. Consequently, this is not mentioned in the readme.

✏️When a solidity linting npm package is added, updating the readme to reflect the linter should be part of that ticket (although perhaps under a larger story of aligning the dev tools and scripts)
- the OpenST readme instructs adding `./node_modules/.bin` to the PATH. There was an internal discussion about relying on locally-installed NPM packages rather than globally. There appears to have been a consensus in favor of this approach, but it was only adopted in `openst-contracts`.

✏️ If the scripts in this readme will be updated to use locally-installed packages, that ticket should also include updating the readme to include this instruction.

Resolves #1.
