### PR TITLE
Removed safemath import from organization contracts

### DIFF
--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.0;
 //
 // ----------------------------------------------------------------------------
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./OrganizationInterface.sol";
 
 
@@ -35,12 +34,6 @@ import "./OrganizationInterface.sol";
  *         of the `OrganizationInterface`, a notion of an admin does not exist.
  */
 contract Organization is OrganizationInterface {
-
-
-    /* Using */
-
-    using SafeMath for uint256;
-
 
     /* Events */
 

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -22,7 +22,6 @@ pragma solidity ^0.5.0;
 
 import "./OrganizationInterface.sol";
 
-
 /**
  * @title Organization contract handles an organization and its workers.
  *


### PR DESCRIPTION
PR contains changes to remove `SafeMath` import in Organization contract as no SafeMath method is used in it. 

Fixes : #9 